### PR TITLE
Day-1: Client-only deploy with SPA config, health route, admin overlay

### DIFF
--- a/client/api/admin/login.ts
+++ b/client/api/admin/login.ts
@@ -1,0 +1,21 @@
+export const config = { runtime: "edge" };
+
+function bad() { return new Response("unauthorized", { status: 401 }); }
+
+export default async function handler(req: Request) {
+  const url = new URL(req.url);
+  const token = url.searchParams.get("token") || "";
+  const expected = process.env.ADMIN_TOKEN;
+  if (!expected || token !== expected) return bad();
+  const headers = new Headers();
+  headers.set("Set-Cookie", [
+    `dreamnet_admin=1`,
+    `Path=/`,
+    `Secure`,
+    `HttpOnly`,
+    `SameSite=Lax`,
+    `Max-Age=${60 * 60 * 12}`
+  ].join("; "));
+  headers.set("Location", "/");
+  return new Response(null, { status: 302, headers });
+}

--- a/client/api/admin/logout.ts
+++ b/client/api/admin/logout.ts
@@ -1,0 +1,15 @@
+export const config = { runtime: "edge" };
+
+export default async function handler() {
+  const headers = new Headers();
+  headers.set("Set-Cookie", [
+    `dreamnet_admin=;`,
+    `Path=/`,
+    `Secure`,
+    `HttpOnly`,
+    `SameSite=Lax`,
+    `Max-Age=0`
+  ].join("; "));
+  headers.set("Location", "/");
+  return new Response(null, { status: 302, headers });
+}

--- a/client/api/health.ts
+++ b/client/api/health.ts
@@ -1,0 +1,5 @@
+export const config = { runtime: "edge" };
+
+export default function handler() {
+  return new Response("ok", { status: 200, headers: { "content-type": "text/plain" } });
+}

--- a/client/src/components/AdminOverlay.tsx
+++ b/client/src/components/AdminOverlay.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { governor } from "../governor/config";
+
+function getCookie(name: string) {
+  return document.cookie.split("; ").find((c) => c.startsWith(name + "="));
+}
+const isAdmin = () => !!getCookie("dreamnet_admin");
+
+export default function AdminOverlay() {
+  const [open, setOpen] = React.useState(false);
+  const [isAdminView, setIsAdminView] = React.useState(isAdmin());
+
+  React.useEffect(() => {
+    setIsAdminView(isAdmin());
+  }, []);
+
+  if (!isAdminView) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        right: 16,
+        bottom: 16,
+        zIndex: 9999,
+        background: "rgba(0,0,0,0.8)",
+        color: "#fff",
+        padding: 16,
+        borderRadius: 12,
+        fontFamily:
+          "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+      }}
+    >
+      <button onClick={() => setOpen(!open)} style={{ marginBottom: 8 }}>
+        {open ? "\u25B2" : "\u25BC"} Admin Overlay
+      </button>
+      {open && (
+        <div style={{ minWidth: 280 }}>
+          <div
+            style={{
+              opacity: 0.8,
+              fontSize: 12,
+              marginBottom: 8,
+            }}
+          >
+            Mode: <b>{governor.mode}</b> · QPS: <b>{governor.maxQPS}</b> ·
+            Concurrency: <b>{governor.maxConcurrency}</b>
+          </div>
+          <ul style={{ margin: 0, paddingLeft: 16 }}>
+            <li>
+              Simulation: <b>{String(governor.simulation)}</b>
+            </li>
+            <li>
+              Feature: Agents <b>{String(governor.featureAgents)}</b>
+            </li>
+            <li>
+              Feature: Payments <b>{String(governor.featurePayments)}</b>
+            </li>
+          </ul>
+          <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
+            <a href="/api/admin/logout" style={{ color: "#ddd" }}>
+              Logout
+            </a>
+            <a
+              href="/api/health"
+              style={{ color: "#ddd" }}
+              target="_blank"
+              rel="noreferrer"
+            >
+              /health
+            </a>
+          </div>
+          <div
+            style={{
+              marginTop: 8,
+              borderTop: "1px solid #333",
+              paddingTop: 8,
+              fontSize: 12,
+              opacity: 0.8,
+            }}
+          >
+            Speedometer (placeholder): show p50/p95 from Vercel Analytics,
+            errors, spend.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/governor/config.ts
+++ b/client/src/governor/config.ts
@@ -1,0 +1,11 @@
+export type GovernorMode = "closed" | "canary" | "open";
+
+export const governor = {
+  mode: (import.meta.env.VITE_GOVERNOR_MODE as GovernorMode) ?? "canary",
+  maxQPS: Number(import.meta.env.VITE_GOVERNOR_MAX_QPS ?? 2),
+  maxConcurrency: Number(import.meta.env.VITE_GOVERNOR_MAX_CONCURRENCY ?? 5),
+  queueLimit: Number(import.meta.env.VITE_GOVERNOR_QUEUE_LIMIT ?? 20),
+  simulation: String(import.meta.env.VITE_SIMULATION_MODE ?? "true") === "true",
+  featureAgents: String(import.meta.env.VITE_FEATURE_AGENTS ?? "false") === "true",
+  featurePayments: String(import.meta.env.VITE_FEATURE_PAYMENTS ?? "false") === "true"
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,12 @@
+import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import AdminOverlay from "./components/AdminOverlay";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+    <AdminOverlay />
+  </React.StrictMode>
+);

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,13 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public,max-age=31536000,immutable" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the Day-1 client-only deployment files:

- `client/vercel.json` to enable SPA rewrites and immutable asset caching.
- `client/api/health.ts` to provide a 200 OK health endpoint.
- `client/api/admin/login.ts` and `client/api/admin/logout.ts` for admin token login/logout (Edge runtime).
- `client/src/governor/config.ts` to expose governor settings via VITE_ env vars.
- `client/src/components/AdminOverlay.tsx` to display an admin overlay with governor info and actions.
- Updates `client/src/main.tsx` to import and render `AdminOverlay` alongside `App` within `React.StrictMode`.

These changes enable a Vite SPA deployment on Vercel with an admin overlay for controlling modes and viewing metrics. Missing secrets will still need to be set in Vercel envs.