### PR TITLE
feat(api/daemon): add ping and tick endpoints

### DIFF
--- a/api/daemon/ping.ts
+++ b/api/daemon/ping.ts
@@ -1,0 +1,6 @@
+export default async function handler(_req: any, res: any) {
+  return res.status(200).json({
+    ok: true,
+    message: 'Ping success'
+  });
+}

--- a/api/daemon/tick.ts
+++ b/api/daemon/tick.ts
@@ -1,0 +1,6 @@
+export default async function handler(_req: any, res: any) {
+  return res.status(200).json({
+    ok: true,
+    message: 'daemon tick'
+  });
+}


### PR DESCRIPTION
This PR imports two endpoints from the old DreamForge daemon into the new DreamNet v2 codebase. It adds `/api/daemon/ping.ts` and `/api/daemon/tick.ts` endpoints that return simple JSON responses for ping and tick. This brings the new repository closer to feature parity.

No other changes.