### PR TITLE
Add AGENTS.md for Codex and DevOps instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS
+role: "Repo caretaker for DreamNet"
+languages: ["TypeScript","Python"]
+build: ["pnpm install","pnpm build"]
+test: ["pnpm test -i --reporter=dot"]
+ci_notes: "Use GitHub Actions. Do not add new services."
+merge_policy: "Open PR. Never push to main."
+code_style: "Prettier + ESLint"
+reviewers: ["brandon-ducar"]
+risk_checks:
+  - "Run tests"
+  - "Explain changes in PR body"
+tasks_allowed:
+  - "Fix build/test"
+  - "Small refactors"
+  - "Typed API clients"


### PR DESCRIPTION
This PR adds an `AGENTS.md` file that outlines the Codex and DevOps instructions for this repository. It defines the role for the repo caretaker, specifies supported languages (TypeScript and Python), lists build and test commands, provides CI notes (use GitHub Actions; don't add new services), establishes the merge policy (open PRs and never push to main), and records code style, reviewers, risk checks, and tasks allowed. 

**Risk:** Low. This change is purely documentation and does not modify any application code.